### PR TITLE
Remove '-enable-si-waitcnts'

### DIFF
--- a/clang-ocl.in
+++ b/clang-ocl.in
@@ -76,7 +76,6 @@ ${CLANG} \
 -m64 \
 -cl-kernel-arg-info \
 -mllvm -amdgpu-internalize-symbols -mllvm -amdgpu-early-inline-all \
--mllvm -enable-si-insert-waitcnts \
 ${options} -o ${output_file} ${output_file}.linked.bc
 
 # Remove extra files


### PR DESCRIPTION
The option is no longer accepted; it is obsolete and should
be removed. See https://reviews.llvm.org/rL333303