### PR TITLE
Update option that forces code object v2

### DIFF
--- a/clang-ocl.in
+++ b/clang-ocl.in
@@ -49,7 +49,7 @@ ${CLANG} -c -emit-llvm \
 -cl-kernel-arg-info \
 -cl-std=CL1.2 \
 -mllvm -amdgpu-early-inline-all \
--mno-code-object-v3 \
+-Xclang -target-feature -Xclang -code-object-v3 \
 -Xclang -cl-ext=+cl_khr_fp64,+cl_khr_global_int32_base_atomics,+cl_khr_global_int32_extended_atomics,+cl_khr_local_int32_base_atomics,+cl_khr_local_int32_extended_atomics,+cl_khr_int64_base_atomics,+cl_khr_int64_extended_atomics,+cl_khr_3d_image_writes,+cl_khr_byte_addressable_store,+cl_khr_gl_sharing,+cl_amd_media_ops,+cl_amd_media_ops2,+cl_khr_subgroups \
 -include ${OPENCL_ROOT}/include/opencl-c.h \
 ${options} -o ${output_file}.orig.bc ${input_file}
@@ -77,7 +77,7 @@ ${CLANG} \
 -m64 \
 -cl-kernel-arg-info \
 -mllvm -amdgpu-internalize-symbols -mllvm -amdgpu-early-inline-all \
--mno-code-object-v3 \
+-Xclang -target-feature -Xclang -code-object-v3 \
 ${options} -o ${output_file} ${output_file}.linked.bc
 
 # Remove extra files


### PR DESCRIPTION
Replace '-mno-code-object-v3' with '-Xclang -target-feature -Xclang -code-object-v3',
which is available since rocm 1.9.0.