### PR TITLE
Fix incorrect case statement.

### DIFF
--- a/clang-ocl.in
+++ b/clang-ocl.in
@@ -25,7 +25,7 @@ do
         ;;
     -mcpu=gfx*)
         gfxip=${1##*gfx}
-        ;&
+        ;;
     -*)
         options="${options} $1"
         ;;


### PR DESCRIPTION
Fix incorrect bash case statement. Should be `;;` not `;&`.