### PR TITLE
Allow option or value to begin with "+"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ include(ROCMSetupVersion)
 include(ROCMCreatePackage)
 include(CTest)
 
-rocm_setup_version(VERSION 0.4.0)
+rocm_setup_version(VERSION 0.5.0)
 
 find_path(OPENCL_ROOT lib/x86_64/bitcode/opencl.amdgcn.bc
     PATH_SUFFIXES 

--- a/clang-ocl.in
+++ b/clang-ocl.in
@@ -26,7 +26,7 @@ do
     -mcpu=gfx*)
         gfxip=${1##*gfx}
         ;&
-    -*)
+    [-\+]*)
         options="${options} $1"
         ;;
     *)


### PR DESCRIPTION
This is required to enforce CO v3 during offline OpenCL compilation, see here (link to the private repo):
https://github.com/AMDComputeLibraries/MLOpen/blob/8f667e169629940e23e0ec9f29e10e2e51f717a9/src/hipoc/hipoc_program.cpp#L123