### PR TITLE
Fix OpenCL dependency to check for libOpenCL.so.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ include(CTest)
 
 rocm_setup_version(VERSION 0.5.0)
 
-find_path(OPENCL_ROOT lib/x86_64/bitcode/opencl.amdgcn.bc
+find_path(OPENCL_ROOT lib/x86_64/libOpenCL.so.1
     PATH_SUFFIXES 
         opencl
         lib/opencl


### PR DESCRIPTION
The OpenCL package has remove the older bitcode/opencl.amdgcn.bc because it is already provided by rocm-device-libs package. Therefore, let's check for the libOpenCL.so rather than the bitcode file.