### PR TITLE
Allow cmake arguments to pass a path for CLANG_BIN

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,8 +25,8 @@ if(NOT HCC_BIN)
     message(FATAL_ERROR "Can't find hcc")
 endif()
 
-set(CLANG_BIN "${HCC_BIN}")
-set(BITCODE_DIR "${HCC_BIN}/../lib")
+set(CLANG_BIN "${HCC_BIN}" CACHE STRING "")
+set(BITCODE_DIR "${HCC_BIN}/../lib" CACHE STRING "")
 
 message("")
 message("--------CLANG_BIN: ${CLANG_BIN}")


### PR DESCRIPTION
We need to allow the CI to pass a hard-coded CLANG_BIN and BITCODE_DIR so that the end-user installing this has the correct path.