### PR TITLE
Switch clang-ocl dependency on rocm-dev package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,8 +44,8 @@ add_subdirectory(test)
 
 install(PROGRAMS ${CLANG_OCL} DESTINATION bin)
 
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "rocm-opencl-dev")
-set(CPACK_RPM_PACKAGE_REQUIRES "rocm-opencl-devel")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "rocm-dev")
+set(CPACK_RPM_PACKAGE_REQUIRES "rocm-dev")
 rocm_create_package(
     NAME rocm-clang-ocl
     DESCRIPTION "OpenCL compilation with clang compiler."


### PR DESCRIPTION
Replace package dependency on opencl with rocm-dev which includes either hcc or hip-clang.