### PR TITLE
Revert "Update CMakeLists.txt: rocm-opencl-devel to rocm-opencl-dev for RPM Requires"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ add_subdirectory(test)
 install(PROGRAMS ${CLANG_OCL} DESTINATION bin)
 
 set(CPACK_DEBIAN_PACKAGE_DEPENDS "rocm-opencl-dev")
-set(CPACK_RPM_PACKAGE_REQUIRES "rocm-opencl-dev")
+set(CPACK_RPM_PACKAGE_REQUIRES "rocm-opencl-devel")
 rocm_create_package(
     NAME rocm-clang-ocl
     DESCRIPTION "OpenCL compilation with clang compiler."


### PR DESCRIPTION
Reverts RadeonOpenCompute/clang-ocl#22 - sorry for the trash, this must be reverted due to unrealized packaging conflicts.