### PR TITLE
Add missing space in bash if

### DIFF
--- a/clang-ocl.in
+++ b/clang-ocl.in
@@ -33,7 +33,7 @@ do
     shift
 done
 
-if [-e $BITCODE_DIR/opencl.amdgcn.bc ]; then
+if [ -e $BITCODE_DIR/opencl.amdgcn.bc ]; then
   BITCODE_PREF="-Xclang -mlink-bitcode-file -Xclang"
   BITCODE_ARGS="-nogpulib \
     $BITCODE_PREF $BITCODE_DIR/opencl.amdgcn.bc \


### PR DESCRIPTION
New bitcode logic missed a space in the if statement, causing older clients to fail.