### PR TITLE
Fix missing tee to check on warnings

### DIFF
--- a/clang-ocl.in
+++ b/clang-ocl.in
@@ -64,7 +64,7 @@ ${CLANG} -c -emit-llvm \
 -Xclang -cl-ext=+cl_khr_fp64,+cl_khr_global_int32_base_atomics,+cl_khr_global_int32_extended_atomics,+cl_khr_local_int32_base_atomics,+cl_khr_local_int32_extended_atomics,+cl_khr_int64_base_atomics,+cl_khr_int64_extended_atomics,+cl_khr_3d_image_writes,+cl_khr_byte_addressable_store,+cl_khr_gl_sharing,+cl_amd_media_ops,+cl_amd_media_ops2,+cl_khr_subgroups \
 -include ${OPENCL_INCLUDE}/opencl-c.h \
 ${BITCODE_ARGS} \
-${options} -o ${output_file}.linked.bc ${input_file}
+${options} -o ${output_file}.linked.bc ${input_file} |& tee ${output_file}.linked.bc.out
 
 # Fail on warnings
 if grep -qi warning ${output_file}.linked.bc.out; then


### PR DESCRIPTION
Previously tee produced a ${output_file}.linked.bc.out which is used to check and fail on warnings. However after removal of llvm-link step, we missed this out file. It is needed for line 70 check.