### PR TITLE
Fix redundant link with device-libs

### DIFF
--- a/clang-ocl.in
+++ b/clang-ocl.in
@@ -71,6 +71,7 @@ ${CLANG} \
 -O3 \
 -m64 \
 -cl-kernel-arg-info \
+-nogpulib \
 -mllvm -amdgpu-internalize-symbols -mllvm -amdgpu-early-inline-all \
 -Xclang -target-feature -Xclang -code-object-v3 \
 ${options} -o ${output_file} ${output_file}.linked.bc


### PR DESCRIPTION
Since linking with device-libs is already completed in
first CLANG step, skip linking with device-libs in second step.
Recently AMDGPU ToolChain has the default behaviour to link
with installed ROCm installation or fail.