### PR TITLE
Add the compiler as a dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,8 +65,8 @@ add_subdirectory(test)
 
 install(PROGRAMS ${CLANG_OCL} DESTINATION bin)
 
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "rocm-opencl-dev")
-set(CPACK_RPM_PACKAGE_REQUIRES "rocm-opencl-devel")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "llvm-amdgpu, rocm-opencl-dev")
+set(CPACK_RPM_PACKAGE_REQUIRES "llvm-amdgpu, rocm-opencl-devel")
 rocm_create_package(
     NAME rocm-clang-ocl
     DESCRIPTION "OpenCL compilation with clang compiler."


### PR DESCRIPTION
As opencl uses comgr for compilation, it no longer has the compiler as a dependency.