### PR TITLE
Include bitcode file for code object v4

### DIFF
--- a/clang-ocl.in
+++ b/clang-ocl.in
@@ -89,9 +89,6 @@ else
     BC_SUFFIX="bc"
 fi
 
-echo "DBG: $codeobjver"
-exit
-
 BITCODE_ARGS="$BITCODE_DIR/opencl.$BC_SUFFIX \
     $BITCODE_DIR/ocml.$BC_SUFFIX \
     $BITCODE_DIR/ockl.$BC_SUFFIX \

--- a/clang-ocl.in
+++ b/clang-ocl.in
@@ -52,6 +52,7 @@ LLVM_LINK=${CLANG_BIN}/llvm-link
 TRIPLE=@TRIPLE@
 
 gfxip=803
+codeobjver=4
 
 while (( "$#" ))
 do
@@ -63,6 +64,13 @@ do
         ;;
     -mcpu=gfx*)
         gfxip=${1##*gfx}
+        ;&
+    -mcode-object-version=*)
+        codeobjver=${1##*=}
+        if [ "$codeobjver" -le 4 ]; then
+            codeobjver=4
+        fi
+        options="${options} $1"
         ;&
     [-\+]*)
         options="${options} $1"
@@ -84,7 +92,7 @@ fi
 BITCODE_ARGS="$BITCODE_DIR/opencl.$BC_SUFFIX \
     $BITCODE_DIR/ocml.$BC_SUFFIX \
     $BITCODE_DIR/ockl.$BC_SUFFIX \
-    $BITCODE_DIR/oclc_abi_version_400.$BC_SUFFIX \
+    $BITCODE_DIR/oclc_abi_version_${codeobjver}00.$BC_SUFFIX \
     $BITCODE_DIR/oclc_correctly_rounded_sqrt_off.$BC_SUFFIX \
     $BITCODE_DIR/oclc_daz_opt_on.$BC_SUFFIX \
     $BITCODE_DIR/oclc_finite_only_off.$BC_SUFFIX \

--- a/clang-ocl.in
+++ b/clang-ocl.in
@@ -62,15 +62,15 @@ do
         shift
         output_file=$1
         ;;
-    -mcpu=gfx*)
-        gfxip=${1##*gfx}
-        ;&
     -mcode-object-version=*)
         codeobjver=${1##*=}
         if [ "$codeobjver" -le 4 ]; then
             codeobjver=4
         fi
         options="${options} $1"
+        ;;
+    -mcpu=gfx*)
+        gfxip=${1##*gfx}
         ;&
     [-\+]*)
         options="${options} $1"
@@ -88,6 +88,9 @@ if [ -e $BITCODE_DIR/opencl.amdgcn.bc ]; then
 else
     BC_SUFFIX="bc"
 fi
+
+echo "DBG: $codeobjver"
+exit
 
 BITCODE_ARGS="$BITCODE_DIR/opencl.$BC_SUFFIX \
     $BITCODE_DIR/ocml.$BC_SUFFIX \

--- a/clang-ocl.in
+++ b/clang-ocl.in
@@ -84,6 +84,7 @@ fi
 BITCODE_ARGS="$BITCODE_DIR/opencl.$BC_SUFFIX \
     $BITCODE_DIR/ocml.$BC_SUFFIX \
     $BITCODE_DIR/ockl.$BC_SUFFIX \
+    $BITCODE_DIR/oclc_abi_version_400.$BC_SUFFIX \
     $BITCODE_DIR/oclc_correctly_rounded_sqrt_off.$BC_SUFFIX \
     $BITCODE_DIR/oclc_daz_opt_on.$BC_SUFFIX \
     $BITCODE_DIR/oclc_finite_only_off.$BC_SUFFIX \


### PR DESCRIPTION
The link step of clang-ocl needs to include a library file with
the ABI version symbol definition. The version include is for
code object v4.